### PR TITLE
Add auth for all HTTP APIs using shared secret Bearer token

### DIFF
--- a/vendor/github.com/minio/minio-go/go.mod
+++ b/vendor/github.com/minio/minio-go/go.mod
@@ -12,3 +12,5 @@ require (
 	golang.org/x/text v0.3.0 // indirect
 	gopkg.in/ini.v1 v1.41.0
 )
+
+go 1.13


### PR DESCRIPTION
While running
$ ./mini-kv --token=$TOKEN

will require all clients to pass in a "Authorization: Bearer $TOKEN" in the header
if the --token flag is not specified or is empty then auth is disabled.

Signed-off-by: Utsav Anand <utsavanand2@gmail.com>