### PR TITLE
Optional read secret from mount path

### DIFF
--- a/main.go
+++ b/main.go
@@ -214,7 +214,21 @@ func connect(ssl bool, secret string, access string, host string) (*minio.Client
 
 func main() {
 	ssl := false
+
 	secret := os.Getenv("MINIO_SECRET_KEY")
+	if val, ok := os.LookupEnv("MINIO_SECRET_KEY_MOUNT_PATH"); ok && len(val) > 0 {
+		log.Println("Found MINIO_SECRET_KEY_MOUNT_PATH in environment.")
+		secretData, err := ioutil.ReadFile(val)
+		if err == nil {
+			secret = string(secretData)
+			log.Println("Using data from MINIO_SECRET_KEY_MOUNT_PATH.")
+		} else {
+			log.Printf("Error reading from %s. Using MINIO_SECRET_KEY instead.", val)
+		}
+	} else {
+		log.Println("Not found MINIO_SECRET_KEY_MOUNT_PATH in environment. Using MINIO_SECRET_KEY instead.")
+	}
+
 	access := os.Getenv("MINIO_ACCESS_KEY")
 	host := os.Getenv("host")
 	port := "8080"

--- a/main.go
+++ b/main.go
@@ -221,7 +221,7 @@ func main() {
 		secretData, err := ioutil.ReadFile(val)
 		if err == nil {
 			secret = string(secretData)
-			log.Println("Using data from MINIO_SECRET_KEY_MOUNT_PATH.")
+			log.Printf("Using data from MINIO_SECRET_KEY_MOUNT_PATH: >>%s<<", secret)
 		} else {
 			log.Printf("Error reading from %s. Using MINIO_SECRET_KEY instead.", val)
 		}

--- a/main.go
+++ b/main.go
@@ -221,7 +221,7 @@ func main() {
 		secretData, err := ioutil.ReadFile(val)
 		if err == nil {
 			secret = string(secretData)
-			log.Printf("Using data from MINIO_SECRET_KEY_MOUNT_PATH: >>%s<<", secret)
+			log.Println("Using data from MINIO_SECRET_KEY_MOUNT_PATH.")
 		} else {
 			log.Printf("Error reading from %s. Using MINIO_SECRET_KEY instead.", val)
 		}


### PR DESCRIPTION
This PR implements the changes of #3 

MINIO_SECRET_KEY is the default Source of the Secret. If MINIO_SECRET_KEY_MOUNT_PATH is present, minio-kv try to read the secret from the file provided in MINIO_SECRET_KEY_MOUNT_PATH. If there is any error, the fallback is MINIO_SECRET_KEY.

Starting Minio:
<img width="1662" alt="Bildschirmfoto 2019-10-13 um 12 01 44" src="https://user-images.githubusercontent.com/348498/66714111-f4e32800-edb2-11e9-936c-4d8747b01046.png">

Building + Starting minio-kv:
<img width="1418" alt="Bildschirmfoto 2019-10-13 um 12 03 24" src="https://user-images.githubusercontent.com/348498/66714136-4b506680-edb3-11e9-8ec5-1608a89ac980.png">


Testing:
<img width="575" alt="Bildschirmfoto 2019-10-13 um 12 03 34" src="https://user-images.githubusercontent.com/348498/66714130-3bd11d80-edb3-11e9-9b99-ff355b48bb4d.png">
