### PR TITLE
Add k8s Deployment and Service

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -17,14 +17,19 @@ spec:
     spec:
       containers:
       - name: minio-kv
-        image: alexellis2/minio-kv:0.1.0
+        image: alexellis2/minio-kv:0.2.1
         env:
         - name: MINIO_ACCESS_KEY
-          value: 511e8d6c84ee65feda34efdcc5366281a22b6dfd
+          valueFrom:
+            secretKeyRef:
+              name: minio-kv-secrets
+              key: MINIO_ACCESS_KEY
         - name: MINIO_SECRET_KEY
-          value: d88b4816ac11f0ee5efcc5282d2fe9896162a1d6
+          valueFrom:
+            secretKeyRef:
+              name: minio-kv-secrets
+              key: MINIO_SECRET_KEY
         command: [ "minio-kv" ]
-        args: [ "server /tmp/" ]
         ports:
         - containerPort: 9000
         resources:

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio-kv-deployment
+  labels:
+    app: minio-kv
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio-kv
+  template:
+    metadata:
+      labels:
+        app: minio-kv
+    spec:
+      containers:
+      - name: minio-kv
+        image: alexellis2/minio-kv:0.1.0
+        env:
+        - name: MINIO_ACCESS_KEY
+          value: 511e8d6c84ee65feda34efdcc5366281a22b6dfd
+        - name: MINIO_SECRET_KEY
+          value: d88b4816ac11f0ee5efcc5282d2fe9896162a1d6
+        command: [ "minio-kv" ]
+        args: [ "server /tmp/" ]
+        ports:
+        - containerPort: 9000
+        resources:
+          requests:
+            memory: 100Mi
+            cpu: 100m
+          limits:
+            memory: 200Mi
+            cpu: 200m

--- a/k8s/secrets.yaml
+++ b/k8s/secrets.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-kv-secrets
+  labels:
+    app: minio-kv
+data:
+  MINIO_ACCESS_KEY: NTExZThkNmM4NGVlNjVmZWRhMzRlZmRjYzUzNjYyODFhMjJiNmRmZAo= # base64 encoded
+  MINIO_SECRET_KEY: ZDg4YjQ4MTZhYzExZjBlZTVlZmNjNTI4MmQyZmU5ODk2MTYyYTFkNgo= # base64 encoded

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio-kv-service
+  labels:
+    app: minio-kv
+spec:
+  ports:
+    - port: 8080
+      name: clientport
+      targetPort : 9000
+      protocol: TCP
+  selector:
+    app: minio-kv

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   ports:
     - port: 8080
-      name: clientport
+      name: http
       targetPort : 9000
       protocol: TCP
   selector:


### PR DESCRIPTION
Simple Kubernetes Deployment and Service specs for your app. The Deployment basically follows the docker run command from the Testing section of the README. It could be improved by taking those 2 env variables from a Secret object instead of having them in the Deployment itself, I can do that as well.

Unfortunately I have not been able to test it properly due to app errors, but at least the output is consistent between simple docker run and running it on k8s:

<img width="834" alt="minio-k8s-screenshot" src="https://user-images.githubusercontent.com/3593995/66705358-ca975900-ed25-11e9-9e08-dc1c883f9f2e.png">

Perhaps you could help me out a bit with testing it?