### PR TITLE
Add the deployment YAML files, fix the read and write timeouts, and edit the Dockerfile to accept flags in the deployment YAML file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,4 @@ WORKDIR /home/app
 USER app
 EXPOSE 8080
 
-CMD ["minio-kv"]
+ENTRYPOINT ["minio-kv"]

--- a/main.go
+++ b/main.go
@@ -267,8 +267,8 @@ func main() {
 
 	s := &http.Server{
 		Addr:           fmt.Sprintf(":%s", port),
-		ReadTimeout:    60 * time.Second,
-		WriteTimeout:   60 * time.Second,
+		ReadTimeout:    5 * time.Minute,
+		WriteTimeout:   5 * time.Minute,
 		MaxHeaderBytes: 1 << 20,
 		Handler:        r,
 	}

--- a/vendor/github.com/minio/minio-go/go.mod
+++ b/vendor/github.com/minio/minio-go/go.mod
@@ -12,3 +12,5 @@ require (
 	golang.org/x/text v0.3.0 // indirect
 	gopkg.in/ini.v1 v1.41.0
 )
+
+go 1.13

--- a/yaml/deployment.yaml
+++ b/yaml/deployment.yaml
@@ -1,0 +1,81 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio-kv
+  labels:
+    app: minio-kv
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio-kv
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      name: minio-kv
+      labels:
+        app: minio-kv
+    spec:
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: minio-pv-claim
+      containers:
+      - name: minio
+        volumeMounts:
+        - name: data
+          mountPath: "/data"
+        image: minio/minio:RELEASE.2019-10-12T01-39-57Z
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: MINIO_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: minio
+                key: minio-access-key
+          - name: MINIO_SECRET_KEY
+            valueFrom:
+              secretKeyRef:
+                name: minio
+                key: minio-secret-key
+        args:
+          - server
+          - /data
+        ports:
+        - containerPort: 9000
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /minio/health/ready
+            port: 9000
+          initialDelaySeconds: 120
+          periodSeconds: 20
+        livenessProbe:
+          httpGet:
+            path: /minio/health/live
+            port: 9000
+          initialDelaySeconds: 120
+          periodSeconds: 20
+      - name: minio-kv
+        image: utsavanand2/minio-kv:0.1.0
+        imagePullPolicy: Always
+        env:
+          - name: MINIO_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: minio
+                key: minio-access-key
+          - name: MINIO_SECRET_KEY
+            valueFrom:
+              secretKeyRef:
+                name: minio
+                key: minio-secret-key
+          - name: host
+            value: 127.0.0.1:9000
+        command:
+          - minio-kv
+          # - --token=$TOKEN
+        ports:
+        - containerPort: 8080
+          protocol: TCP

--- a/yaml/minio-pvc.yaml
+++ b/yaml/minio-pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: minio-pv-claim
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests: 
+      storage: 10Gi

--- a/yaml/service.yaml
+++ b/yaml/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio-kv-svc
+spec:
+  type: LoadBalancer
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: minio-kv
+  sessionAffinity: None


### PR DESCRIPTION
The YAML files create a pod with minio and minio-kv containers, the read and write timeouts have been extended to 5 mins and the Dockerfile is now modified to use ENTRYPOINT to accept commands from YAML file.